### PR TITLE
Add errors wrapper

### DIFF
--- a/error_test.go
+++ b/error_test.go
@@ -43,6 +43,12 @@ var _ = Describe("wrap package tests", func() {
 			Expect(err.Error()).To(BeEquivalentTo("issue setting up z: failed to do x, because of y"))
 		})
 
+		It("should fall back to a simple error if no cause is provided", func() {
+			err := Error(nil, "failed to do thing A")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(BeEquivalentTo("failed to do thing A"))
+		})
+
 		It("should be able to just extract the context string", func() {
 			switch contextError := err.(type) {
 			case ContextError:
@@ -57,6 +63,66 @@ var _ = Describe("wrap package tests", func() {
 			switch contextError := err.(type) {
 			case ContextError:
 				Expect(contextError.Cause().Error()).To(BeEquivalentTo("failed to do x, because of y"))
+
+			default:
+				Fail("failed to type cast to ContextError")
+			}
+		})
+	})
+
+	Context("wrapping multiple errors with context", func() {
+		var (
+			err = Errorsf(
+				[]error{
+					fmt.Errorf("issue setting up x"),
+					fmt.Errorf("issue setting up y"),
+					fmt.Errorf("issue setting up z"),
+				},
+				"failed to setup component %s", "A",
+			)
+		)
+
+		It("should behave and render like a standard error", func() {
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(BeEquivalentTo("failed to setup component A:\n- issue setting up x\n- issue setting up y\n- issue setting up z"))
+		})
+
+		It("should fall back to a simple error if no cause is provided", func() {
+			err := Errors(nil, "failed to do thing A")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(BeEquivalentTo("failed to do thing A"))
+		})
+
+		It("should render like a simple wrapped error if there is only one error list entry", func() {
+			err := Errorsf(
+				[]error{
+					fmt.Errorf("issue setting up x"),
+				},
+				"failed to setup component %s", "A",
+			)
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(BeEquivalentTo("failed to setup component A: issue setting up x"))
+		})
+
+		It("should be able to just extract the context string", func() {
+			switch contextError := err.(type) {
+			case ListOfErrors:
+				Expect(contextError.Context()).To(BeEquivalentTo("failed to setup component A"))
+
+			default:
+				Fail("failed to type cast to ContextError")
+			}
+		})
+
+		It("should be able to just extract the list of errors", func() {
+			switch contextError := err.(type) {
+			case ListOfErrors:
+				Expect(contextError.Errors()).To(BeEquivalentTo([]error{
+					fmt.Errorf("issue setting up x"),
+					fmt.Errorf("issue setting up y"),
+					fmt.Errorf("issue setting up z"),
+				}))
 
 			default:
 				Fail("failed to type cast to ContextError")


### PR DESCRIPTION
Add a new error that can wrap multiple errors with additional context
information explaining the issue.