### PR TITLE
Prepare sunset of module

### DIFF
--- a/error.go
+++ b/error.go
@@ -23,75 +23,35 @@ package wrap
 import (
 	"errors"
 	"fmt"
-	"strings"
 )
 
 // ContextError interface describes the simple type that is able to provide a
 // textual context as well as the cause explaining the underlying error.
+//
+// Deprecated: Discontinued, use fmt.Errorf() instead.
 type ContextError interface {
 	Context() string
 	Cause() error
 }
 
-// wrappedError describes an error with added context information
-type wrappedError struct {
-	context string
-	cause   error
-}
-
-func (e *wrappedError) Error() string {
-	return fmt.Sprintf("%s: %v", e.context, e.cause)
-}
-
-func (e *wrappedError) Context() string {
-	return e.context
-}
-
-func (e *wrappedError) Cause() error {
-	return e.cause
-}
-
 // ListOfErrors interface describes a list of errors with additional context
 // information with an explanation.
+//
+// Deprecated: Discontinued, use errors.Join() instead.
 type ListOfErrors interface {
 	Context() string
 	Errors() []error
-}
-
-// wrappedErrors describes a list of errors with context information
-type wrappedErrors struct {
-	context string
-	errors  []error
-}
-
-func (e *wrappedErrors) Error() string {
-	tmp := make([]string, len(e.errors))
-	for i, err := range e.errors {
-		tmp[i] = fmt.Sprintf("- %s", err.Error())
-	}
-
-	return fmt.Sprintf("%s:\n%s", e.context, strings.Join(tmp, "\n"))
-}
-
-func (e *wrappedErrors) Context() string {
-	return e.context
-}
-
-func (e *wrappedErrors) Errors() []error {
-	return e.errors
 }
 
 // Error creates an error with additional context
 //
 // Deprecated: Use fmt.Errorf() instead using the `%w` format specifier.
 func Error(err error, context string) error {
-	switch {
-	case err == nil:
+	if err == nil {
 		return errors.New(context)
-
-	default:
-		return &wrappedError{context, err}
 	}
+
+	return fmt.Errorf("%s: %w", context, err)
 }
 
 // Errorf creates an error with additional formatted context
@@ -102,20 +62,27 @@ func Errorf(err error, format string, a ...interface{}) error {
 }
 
 // Errors creates a list of errors with additional context
+//
+// Deprecated: Use fmt.Errorf() and errors.Join() instead.
 func Errors(errs []error, context string) error {
-	switch {
-	case errs == nil:
+	switch len(errs) {
+	case 0:
 		return errors.New(context)
 
-	case len(errs) == 1:
-		return Error(errs[0], context)
+	case 1:
+		return fmt.Errorf("%s: %w", context, errs[0])
 
 	default:
-		return &wrappedErrors{context, errs}
+		return fmt.Errorf("%s:\n%w",
+			context,
+			errors.Join(errs...),
+		)
 	}
 }
 
 // Errorsf creates a list of errors with additional formatted context
+//
+// Deprecated: Use fmt.Errorf() and errors.Join() instead.
 func Errorsf(errors []error, format string, a ...interface{}) error {
 	return Errors(errors, fmt.Sprintf(format, a...))
 }

--- a/error_test.go
+++ b/error_test.go
@@ -48,26 +48,6 @@ var _ = Describe("wrap package tests", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(BeEquivalentTo("failed to do thing A"))
 		})
-
-		It("should be able to just extract the context string", func() {
-			switch contextError := err.(type) {
-			case ContextError:
-				Expect(contextError.Context()).To(BeEquivalentTo("issue setting up z"))
-
-			default:
-				Fail("failed to type cast to ContextError")
-			}
-		})
-
-		It("should be able to just extract the error cause", func() {
-			switch contextError := err.(type) {
-			case ContextError:
-				Expect(contextError.Cause().Error()).To(BeEquivalentTo("failed to do x, because of y"))
-
-			default:
-				Fail("failed to type cast to ContextError")
-			}
-		})
 	})
 
 	Context("wrapping multiple errors with context", func() {
@@ -84,7 +64,7 @@ var _ = Describe("wrap package tests", func() {
 
 		It("should behave and render like a standard error", func() {
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(BeEquivalentTo("failed to setup component A:\n- issue setting up x\n- issue setting up y\n- issue setting up z"))
+			Expect(err.Error()).To(BeEquivalentTo("failed to setup component A:\nissue setting up x\nissue setting up y\nissue setting up z"))
 		})
 
 		It("should fall back to a simple error if no cause is provided", func() {
@@ -95,38 +75,12 @@ var _ = Describe("wrap package tests", func() {
 
 		It("should render like a simple wrapped error if there is only one error list entry", func() {
 			err := Errorsf(
-				[]error{
-					fmt.Errorf("issue setting up x"),
-				},
+				[]error{fmt.Errorf("issue setting up x")},
 				"failed to setup component %s", "A",
 			)
 
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(BeEquivalentTo("failed to setup component A: issue setting up x"))
-		})
-
-		It("should be able to just extract the context string", func() {
-			switch contextError := err.(type) {
-			case ListOfErrors:
-				Expect(contextError.Context()).To(BeEquivalentTo("failed to setup component A"))
-
-			default:
-				Fail("failed to type cast to ContextError")
-			}
-		})
-
-		It("should be able to just extract the list of errors", func() {
-			switch contextError := err.(type) {
-			case ListOfErrors:
-				Expect(contextError.Errors()).To(BeEquivalentTo([]error{
-					fmt.Errorf("issue setting up x"),
-					fmt.Errorf("issue setting up y"),
-					fmt.Errorf("issue setting up z"),
-				}))
-
-			default:
-				Fail("failed to type cast to ContextError")
-			}
 		})
 	})
 


### PR DESCRIPTION
Mark all functions as deprecated.

Mark all exported types as deprecated.

Refactor remaining functions to use standard libraries.
